### PR TITLE
Add hook for when a slide is hiding

### DIFF
--- a/lib/wingtips/presentation.rb
+++ b/lib/wingtips/presentation.rb
@@ -16,17 +16,17 @@ module Wingtips
           go_to_slide(0)
         end
 
-        def on_hide(&block)
-          @on_hide_block = block
+        def on_slide_change(&block)
+          @on_slide_change_block = block
         end
 
-        def hiding
-          @on_hide_block.call if @on_hide_block
+        def slide_changing
+          @on_slide_change_block.call if @on_slide_change_block
         end
 
         def go_to_slide(number)
           clear
-          @current_slide.hiding if @current_slide
+          @current_slide.slide_changing if @current_slide
 
           @current_slide_number = number.to_i
           slide_class = @slides[@current_slide_number]


### PR DESCRIPTION
Found for my fancier slides I needed to do some cleanup (stop animations,
etc.) This hook was the clearest way I could see to plumb that through.
