### PR TITLE
Let image calls pass arguments along

### DIFF
--- a/lib/wingtips/slide.rb
+++ b/lib/wingtips/slide.rb
@@ -95,8 +95,8 @@ module Wingtips
       para ' ', size: BULLET_POINT_SIZE
     end
 
-    def image(path)
-      app.image(File.expand_path(path))
+    def image(path, *args)
+      app.image(File.expand_path(path), *args)
     end
 
     def fullscreen_image(path)


### PR DESCRIPTION
Needed this to do some placement on initialize with them. Could have grabbed
the returned element and set it directly, but wanted the tidier feel
