### PR TITLE
Revised methods for title slides

### DIFF
--- a/lib/wingtips/slide.rb
+++ b/lib/wingtips/slide.rb
@@ -1,16 +1,19 @@
 # encoding: UTF-8
 require 'ext/highlighter'
 
-PHOTO_CREDIT_SIZE = 18
-CODE_SIZE = 30
-BULLET_POINT_SIZE = 40
-HEADLINE_SIZE = 65
-VERY_BIG_SIZE = 80
-ENORMOUS_SIZE = 140
-
 module Wingtips
+  PHOTO_CREDIT_SIZE = 18
+  CODE_SIZE = 30
+  BULLET_POINT_SIZE = 40
+  HEADLINE_SIZE = 65
+  VERY_BIG_SIZE = 80
+  ENORMOUS_SIZE = 140
+
   class Slide
     include HH::Markup
+
+    IMAGES_DIRECTORY  = 'images/'
+    CODE_DIRECTORY    = 'code/'
 
     attr_reader :app
 


### PR DESCRIPTION
Found we only had methods for some sizes, and didn't have a consistent way to
fiddle the formatting when you wanted _almost_ that slide with a little
difference.

Also has a hacky vertical alignment that works ok for single lines of text.
Worth improving later, but gets it done for now.
