### PR TITLE
Support passing startup options for main Shoes.app call

### DIFF
--- a/lib/wingtips/configuration.rb
+++ b/lib/wingtips/configuration.rb
@@ -3,7 +3,10 @@ module Wingtips
     attr_reader :slide_classes, :app_options
 
     def initialize(path)
-      @app_options = {}
+      @app_options = {
+        title:      'Presentation',
+        fullscreen: true
+      }
 
       full_path = File.expand_path(path)
       load_named_slides full_path

--- a/lib/wingtips/presentation.rb
+++ b/lib/wingtips/presentation.rb
@@ -4,14 +4,12 @@ module Wingtips
   module Presentation
     NEXT_KEYS     = [:right, :page_down, " "]
     PREVIOUS_KEYS = [:left,  :page_up, :backspace]
-    DEFAULT_OPTIONS = { title: 'Presentation', fullscreen: true }
 
     def self.start(config)
       slides = config.slide_classes
       puts "Presenting #{slides.size} slides"
 
-      opts = DEFAULT_OPTIONS.merge(config.app_options)
-      Shoes.app(opts) do
+      Shoes.app(config.app_options) do
         @slides = slides
 
         def start

--- a/samples/boo/config.rb
+++ b/samples/boo/config.rb
@@ -1,3 +1,0 @@
-slide do
-  code "Shoes.app do alert 'whatever' end", true
-end


### PR DESCRIPTION
Right now these can be called from anywhere, but are additive to ease that
pain
