### PR TITLE
Title slide template

### DIFF
--- a/lib/wingtips.rb
+++ b/lib/wingtips.rb
@@ -5,8 +5,11 @@ require 'wingtips/hash_utils'
 require 'wingtips/version'
 require 'wingtips/slide'
 require 'wingtips/presentation'
+
+# Default templates
+require 'wingtips/templates/title_slide'
+
 require 'wingtips/dsl'
 
 module Wingtips
-  # Your code goes here...
 end

--- a/lib/wingtips/dsl.rb
+++ b/lib/wingtips/dsl.rb
@@ -4,7 +4,9 @@ module Wingtips
       clazz = create_slide_class content
       publish_slide_class clazz, title
     end
-    
+
+    include Wingtips::Templates::TitleSlide
+
     private
 
     def create_slide_class(content)
@@ -31,7 +33,14 @@ module Wingtips
     end
 
     def unnamed_slides_allowed?
-      configuration.unnamed_slides_allowed?    
+      configuration.unnamed_slides_allowed?
+    end
+
+    # merge order is = defaults, template, custom
+    def merge_template_options(default_options, template_key, custom_options = {})
+      template_options = configuration.template_options.fetch template_key, {}
+      options = Wingtips::HashUtils.deep_merge(default_options, template_options)
+      Wingtips::HashUtils.deep_merge(options, custom_options)
     end
   end
 end

--- a/lib/wingtips/dsl.rb
+++ b/lib/wingtips/dsl.rb
@@ -6,6 +6,7 @@ module Wingtips
     end
     
     private
+
     def create_slide_class(content)
       clazz = Class.new(Wingtips::Slide)
       clazz.class_eval do
@@ -13,7 +14,7 @@ module Wingtips
       end
       clazz
     end
-    
+
     def publish_slide_class(clazz, title)
       if unnamed_slides_allowed? && title.nil?
         @slide_classes << clazz
@@ -24,11 +25,11 @@ module Wingtips
         Object.const_set(title, clazz)
       end
     end
-    
+
     def configuration
       Wingtips::Configuration.current
     end
-    
+
     def unnamed_slides_allowed?
       configuration.unnamed_slides_allowed?    
     end

--- a/lib/wingtips/templates/title_slide.rb
+++ b/lib/wingtips/templates/title_slide.rb
@@ -1,0 +1,23 @@
+module Wingtips
+  module Templates
+    module TitleSlide
+      DEFAULT_TITLE_SLIDE_OPTIONS = {
+        size:           Wingtips::ENORMOUS_SIZE,
+        vertical_align: 'center',
+        weight:         'bold'
+      }.freeze
+
+      def title_slide(name, text, opts={}, &block)
+        options = merge_template_options DEFAULT_TITLE_SLIDE_OPTIONS,
+          :title_slide,
+          opts
+
+        slide(name) do
+          background options[:background] if options[:background]
+          centered_title text, options
+          self.instance_eval(&block) if block
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pulled from get_your_shoes_back_on with a little bit of munging to allow passing a background color. What do you think?

The interesting choice here is the use of a module to include the template. I started out thinking "Oh, I'll make a slide class," but when I went that way I found was annoying. I couldn't just use my slide class to make an instance--a call to `title_slide` actually means generating a child class with its own specific data.

The `slide` method already does this directly via its closure, which is not only is shorter but feels more elegant.

Separate modules also felt good just from an organizational perspective. Don't feel like everything in `DSL` should be busted out, but specific templates like this seem good to separate.