### PR TITLE
Properly initialize for running wingtips executable

### DIFF
--- a/bin/wingtips
+++ b/bin/wingtips
@@ -3,6 +3,9 @@
 require 'bundler/setup'
 Bundler.require
 
+require 'shoes/swt'
+Shoes::Swt.initialize_backend
+
 require 'wingtips/presentation'
 require 'wingtips/configuration'
 


### PR DESCRIPTION
Recent changes for multiple backend support require us to initialize the
SWT backend more directly. Hopefully will have a true multi-backend
solution for executables like this eventually, but for now this gets us
in shape to run against 4.0.0.pre4.

Noted while prepping lightning talk with wingtips: https://github.com/jasonrclark/lightning/tree/master/bundle-exec
